### PR TITLE
Simplify data reset section styling

### DIFF
--- a/src/components/atoms/ResetButton/index.tsx
+++ b/src/components/atoms/ResetButton/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { usePlayerContext } from "../../../contexts/PlayerContext";
 import ConfirmDialog from "../../molecules/ConfirmDialog";
-import { Button, Paper, Typography, Box, Divider } from "@mui/material";
+import { Button, Typography, Box } from "@mui/material";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { useMatchContext } from "../../../contexts/MatchContext";
@@ -27,31 +27,16 @@ const ResetButton: React.FC = () => {
 
   return (
     <>
-      <Paper
-        elevation={1}
-        sx={{
-          p: 2,
-          mb: 2,
-          borderRadius: 2,
-          border: "1px solid rgba(211, 47, 47, 0.2)",
-        }}
-      >
-        <Box
-          sx={{
-            mb: 2,
-            display: "flex",
-            alignItems: "flex-start",
-          }}
-        >
-          <WarningAmberIcon
-            color="error"
-            sx={{
-              mr: 1.5,
-              mt: 0.5,
-            }}
-          />
+      <Box sx={{ mt: 2 }}>
+        <Box sx={{ display: "flex", alignItems: "flex-start", mb: 1.5 }}>
+          <WarningAmberIcon color="error" sx={{ mr: 1.2, mt: 0.4 }} />
           <Box>
-            <Typography variant="h6" align="left">
+            <Typography
+              variant="subtitle1"
+              color="error.main"
+              align="left"
+              sx={{ fontWeight: "bold" }}
+            >
               データリセット
             </Typography>
             <Typography variant="body2" color="text.secondary" align="left">
@@ -59,7 +44,6 @@ const ResetButton: React.FC = () => {
             </Typography>
           </Box>
         </Box>
-        <Divider sx={{ my: 1.5 }} />
         <Button
           onClick={handleReset}
           variant="outlined"
@@ -68,7 +52,6 @@ const ResetButton: React.FC = () => {
           startIcon={<RestartAltIcon />}
           sx={{
             py: 1,
-            mt: 1,
             fontWeight: "bold",
             "&:hover": {
               bgcolor: "rgba(211, 47, 47, 0.08)",
@@ -78,7 +61,7 @@ const ResetButton: React.FC = () => {
         >
           リセット
         </Button>
-      </Paper>
+      </Box>
       {showConfirm && (
         <ConfirmDialog
           confirmText="本当にリセットしますか？"


### PR DESCRIPTION
## Summary
- remove the extra card-like container around the reset controls to integrate them with the surrounding settings card
- keep the warning copy and confirmation dialog while simplifying the layout and emphasis styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe11fe2050832db6c122efe8241f64