### PR TITLE
Update reset section labels

### DIFF
--- a/src/components/atoms/ResetButton/index.tsx
+++ b/src/components/atoms/ResetButton/index.tsx
@@ -30,19 +30,9 @@ const ResetButton: React.FC = () => {
       <Box sx={{ mt: 2 }}>
         <Box sx={{ display: "flex", alignItems: "flex-start", mb: 1.5 }}>
           <WarningAmberIcon color="error" sx={{ mr: 1.2, mt: 0.4 }} />
-          <Box>
-            <Typography
-              variant="subtitle1"
-              color="error.main"
-              align="left"
-              sx={{ fontWeight: "bold" }}
-            >
-              データリセット
-            </Typography>
-            <Typography variant="body2" color="text.secondary" align="left">
-              すべての参加者情報と試合履歴を削除します
-            </Typography>
-          </Box>
+          <Typography variant="body2" color="text.secondary" align="left">
+            すべての参加者情報と試合履歴を削除します
+          </Typography>
         </Box>
         <Button
           onClick={handleReset}

--- a/src/components/atoms/ResetButton/index.tsx
+++ b/src/components/atoms/ResetButton/index.tsx
@@ -3,7 +3,6 @@ import { usePlayerContext } from "../../../contexts/PlayerContext";
 import ConfirmDialog from "../../molecules/ConfirmDialog";
 import { Button, Typography, Box } from "@mui/material";
 import RestartAltIcon from "@mui/icons-material/RestartAlt";
-import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import { useMatchContext } from "../../../contexts/MatchContext";
 
 const ResetButton: React.FC = () => {
@@ -28,12 +27,14 @@ const ResetButton: React.FC = () => {
   return (
     <>
       <Box sx={{ mt: 2 }}>
-        <Box sx={{ display: "flex", alignItems: "flex-start", mb: 1.5 }}>
-          <WarningAmberIcon color="error" sx={{ mr: 1.2, mt: 0.4 }} />
-          <Typography variant="body2" color="text.secondary" align="left">
-            すべての参加者情報と試合履歴を削除します
-          </Typography>
-        </Box>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          align="left"
+          sx={{ mb: 1.5 }}
+        >
+          すべての参加者情報と試合履歴を削除します
+        </Typography>
         <Button
           onClick={handleReset}
           variant="outlined"

--- a/src/components/organisms/SettingsMenu/index.tsx
+++ b/src/components/organisms/SettingsMenu/index.tsx
@@ -68,7 +68,7 @@ const SettingsMenu: React.FC<SettingsMenuProps> = ({
           }}
         >
           <WarningAmberIcon sx={{ mr: 1, fontSize: "1.2rem" }} />
-          データ管理
+          データリセット
         </Typography>
         <ResetButton />
       </Paper>

--- a/src/contexts/MatchContext.tsx
+++ b/src/contexts/MatchContext.tsx
@@ -26,7 +26,6 @@ export const MatchProvider: React.FC<Props> = ({ children }) => {
     availablePlayers,
     pairHistory,
     updatePairHistoryByMatches,
-    opponentHistory,
     updateOpponentHistoryByMatches,
   } = usePlayerContext();
 


### PR DESCRIPTION
## Summary
- rename the settings menu warning section heading to "データリセット"
- remove the redundant "データリセット" label from the reset button details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe174d5608832dbb3f055b8abf23a1