### PR TITLE
Fix reset button color in modal

### DIFF
--- a/src/components/atoms/ResetButton/index.tsx
+++ b/src/components/atoms/ResetButton/index.tsx
@@ -55,6 +55,7 @@ const ResetButton: React.FC = () => {
           cancelText='キャンセル'
           onConfirm={confirmReset}
           onCancel={cancelReset}
+          okColor='error'
         />
       )}
     </>


### PR DESCRIPTION
Change the reset button color in the confirmation modal to red to indicate a destructive operation.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c47e522-8207-4071-98a4-8c06d9b0b07a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c47e522-8207-4071-98a4-8c06d9b0b07a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set `ConfirmDialog` OK button color to `error` in `src/components/atoms/ResetButton/index.tsx` to indicate a destructive reset action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7d155341312d1e5af7b6e533270c29c9e2c1b7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->