### PR TITLE
Keep next match button fixed at bottom

### DIFF
--- a/src/components/MatchTab.tsx
+++ b/src/components/MatchTab.tsx
@@ -205,7 +205,7 @@ export function MatchTab({
   const incompleteCount = state.activeRound.matches.filter((match) => match.winner === null).length;
 
   return (
-    <section className="tab-panel match-tab" aria-labelledby="current-matches-heading">
+    <section className="tab-panel match-tab active-round" aria-labelledby="current-matches-heading">
       <div className="section-heading">
         <p className="section-kicker">Live round</p>
         <h2 id="current-matches-heading">現在の試合</h2>

--- a/src/styles.css
+++ b/src/styles.css
@@ -400,9 +400,15 @@ dd {
   padding: 14px;
 }
 
+.match-tab.active-round {
+  padding-bottom: 96px;
+}
+
 .action-bar {
-  position: sticky;
+  position: fixed;
+  right: 14px;
   bottom: calc(var(--nav-height) + env(safe-area-inset-bottom) + 10px);
+  left: 14px;
   z-index: 4;
   display: grid;
   gap: 8px;
@@ -864,8 +870,14 @@ dd {
     gap: 8px;
   }
 
+  .match-tab.active-round {
+    padding-bottom: 78px;
+  }
+
   .match-tab .action-bar {
+    right: 10px;
     bottom: calc(var(--nav-height) + env(safe-area-inset-bottom) + 8px);
+    left: 10px;
     gap: 6px;
     padding: 8px;
   }
@@ -1064,6 +1076,11 @@ dd {
 @media (min-width: 680px) {
   .app-main {
     padding: 24px 24px 32px;
+  }
+
+  .action-bar {
+    right: max(24px, calc((100vw - 960px) / 2 + 24px));
+    left: max(24px, calc((100vw - 960px) / 2 + 24px));
   }
 
   .winner-actions,


### PR DESCRIPTION
### Motivation
- Ensure the "次の試合を生成" (Next match) action is always accessible by keeping it visually fixed above the bottom navigation while a round is active.
- Reserve bottom spacing only when an active round exists so other tabs/layouts are unaffected.

### Description
- Add `active-round` class to the match panel when `state.activeRound` is present to scope layout changes (`src/components/MatchTab.tsx`).
- Change the `.action-bar` from `position: sticky` to `position: fixed` and add left/right offsets so the action bar is pinned above the bottom nav (`src/styles.css`).
- Add bottom padding to `.match-tab.active-round` so content does not get obscured by the fixed action bar, and adjust responsive offsets for small and wide viewports (`src/styles.css`).

### Testing
- Ran `npm test` (Vitest) and all tests passed: 8 test files, 73 tests passed.
- Ran `npm run build` and a production build completed successfully.
- An attempt to run `npm test -- --runInBand` failed because Vitest does not accept the `--runInBand` option, which is unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4129f819c4832d80245a8ebe1973b1)